### PR TITLE
Fix lint issues in health check and Supabase test page

### DIFF
--- a/netlify/functions/health-check.ts
+++ b/netlify/functions/health-check.ts
@@ -7,14 +7,26 @@ export const handler: Handler = async (event) => {
 
   try {
     // Test Supabase connection
-    const SUPABASE_URL = process.env.SUPABASE_URL || 'https://vkwhrbjkdznncjkzkiuo.supabase.co';
-    const SUPABASE_PUBLIC_API_KEY = process.env.SUPABASE_PUBLIC_API_KEY || 'sb_publishable_Ujfa9-Q184jwhMXRHt3NFQ_DGXvAcDs';
+    const SUPABASE_URL = process.env.SUPABASE_URL;
+    const SUPABASE_PUBLIC_API_KEY = process.env.SUPABASE_PUBLIC_API_KEY;
+
+    if (!SUPABASE_URL || !SUPABASE_PUBLIC_API_KEY) {
+      return {
+        statusCode: 500,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          status: 'error',
+          message: 'Missing Supabase configuration',
+          timestamp: new Date().toISOString()
+        })
+      };
+    }
 
     const { createClient } = await import('@supabase/supabase-js');
     const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLIC_API_KEY);
 
     // Test database connection
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('search_state')
       .select('*')
       .limit(1);
@@ -47,14 +59,14 @@ export const handler: Handler = async (event) => {
       })
     };
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     return {
       statusCode: 500,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         status: 'error',
         message: 'Health check failed',
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
         timestamp: new Date().toISOString()
       })
     };

--- a/src/pages/api/test-supabase.astro
+++ b/src/pages/api/test-supabase.astro
@@ -2,16 +2,25 @@
 // Test endpoint to verify Supabase connection from Netlify
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = import.meta.env.SUPABASE_URL || 
-                     import.meta.env.VITE_SUPABASE_URL || 
-                     'https://vkwhrbjkdznncjkzkiuo.supabase.co';
+const SUPABASE_URL = import.meta.env.SUPABASE_URL ||
+                     import.meta.env.VITE_SUPABASE_URL;
 
-const SUPABASE_PUBLIC_API_KEY = import.meta.env.SUPABASE_PUBLIC_API_KEY || 
-                               import.meta.env.VITE_SUPABASE_ANON_KEY ||
-                               'sb_publishable_Ujfa9-Q184jwhMXRHt3NFQ_DGXvAcDs';
+const SUPABASE_PUBLIC_API_KEY = import.meta.env.SUPABASE_PUBLIC_API_KEY ||
+                               import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (Astro.request.method === 'POST') {
   try {
+    if (!SUPABASE_URL || !SUPABASE_PUBLIC_API_KEY) {
+      return new Response(JSON.stringify({
+        success: false,
+        error: 'Missing Supabase configuration',
+        timestamp: new Date().toISOString()
+      }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLIC_API_KEY);
     
     // Test database connection
@@ -43,10 +52,10 @@ if (Astro.request.method === 'POST') {
       headers: { 'Content-Type': 'application/json' }
     });
 
-  } catch (error: any) {
+  } catch (error: unknown) {
     return new Response(JSON.stringify({
       success: false,
-      error: error.message,
+      error: error instanceof Error ? error.message : String(error),
       timestamp: new Date().toISOString()
     }), {
       status: 500,
@@ -81,7 +90,7 @@ if (Astro.request.method === 'POST') {
     Environment: {import.meta.env.MODE || 'production'}
   </div>
 
-  <button onclick="testConnection()">Test Supabase Connection</button>
+  <button id="test-connection">Test Supabase Connection</button>
   
   <div id="result"></div>
 
@@ -126,6 +135,10 @@ if (Astro.request.method === 'POST') {
         `;
       }
     }
+
+    document
+      .getElementById('test-connection')
+      ?.addEventListener('click', testConnection);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require Supabase env vars in Netlify health check
- validate Supabase configuration on test endpoint and bind button click via event listener
- tighten error typing to avoid `any`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad9a1d78648329a1fd37fcc2b9a829
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Require Supabase env vars and validate config in the Netlify health check and test page to avoid silent misconfigurations. Removed hardcoded fallbacks, improved error handling, and fixed minor lint issues.

- **Bug Fixes**
  - Health check now returns 500 if SUPABASE_URL or SUPABASE_PUBLIC_API_KEY is missing.
  - Test endpoint validates config and returns clear JSON errors; no default values used.
  - Safer error typing (unknown + instanceof Error) to replace any.
  - Test page binds the button via an event listener instead of inline onclick.

<!-- End of auto-generated description by cubic. -->

