### PR TITLE
Add script to configure git remote and GitHub CLI

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,6 +49,15 @@ Git branch synchronization and divergence resolution tool.
 - `rebase` - Rebase local changes onto remote
 - `reset` - Reset local branch to match remote (destructive)
 
+### 3. `setup_remote_and_gh_cli.sh`
+Automates configuring a Git remote and installing the GitHub CLI.
+
+**Usage:**
+```bash
+./scripts/setup_remote_and_gh_cli.sh <remote-url> [remote-name]
+```
+
+
 ## Quick Start
 
 ### Daily Health Check

--- a/scripts/setup_remote_and_gh_cli.sh
+++ b/scripts/setup_remote_and_gh_cli.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Setup Git remote and GitHub CLI
+# Usage: ./scripts/setup_remote_and_gh_cli.sh <remote-url> [remote-name]
+# Example: ./scripts/setup_remote_and_gh_cli.sh https://github.com/user/repo.git origin
+
+set -euo pipefail
+
+REMOTE_URL=${1:-}
+REMOTE_NAME=${2:-origin}
+
+if [ -z "$REMOTE_URL" ]; then
+  echo "Usage: $0 <remote-url> [remote-name]"
+  exit 1
+fi
+
+# Configure git remote
+if git remote | grep -q "^${REMOTE_NAME}$"; then
+  echo "Remote '$REMOTE_NAME' already exists. Updating URL..."
+  git remote set-url "$REMOTE_NAME" "$REMOTE_URL"
+else
+  echo "Adding remote '$REMOTE_NAME' with URL '$REMOTE_URL'"
+  git remote add "$REMOTE_NAME" "$REMOTE_URL"
+fi
+
+# Ensure gh is installed
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI not found. Installing..."
+  if command -v apt-get >/dev/null 2>&1; then
+    type -p curl >/dev/null 2>&1 || sudo apt-get update && sudo apt-get install -y curl
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+    sudo apt-get update
+    sudo apt-get install -y gh
+  else
+    echo "Unsupported platform: please install GitHub CLI manually"
+    exit 1
+  fi
+else
+  echo "GitHub CLI already installed."
+fi
+
+# Prompt to authenticate
+echo "GitHub CLI installed. Run 'gh auth login' to authenticate."
+
+# Set upstream for main branch if it exists
+if git show-ref --verify --quiet refs/heads/main; then
+  git fetch "$REMOTE_NAME"
+  git branch --set-upstream-to "$REMOTE_NAME/main" main || true
+fi
+


### PR DESCRIPTION
## Summary
- add `setup_remote_and_gh_cli.sh` to install GitHub CLI and configure git remote
- document new script usage in scripts README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b1fe3b948329bfff2a926bbd516d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a script to automate Git remote setup and GitHub CLI installation, with usage documented in the scripts README. This speeds onboarding and ensures consistent local repo configuration.

- **New Features**
  - setup_remote_and_gh_cli.sh adds/updates a remote (default: origin) from a provided URL.
  - Installs GitHub CLI via apt on Debian/Ubuntu if missing; otherwise exits with a manual install notice.
  - Fetches remote and sets upstream for main if it exists; prompts to run gh auth login.
  - README updated with a usage example.

<!-- End of auto-generated description by cubic. -->

